### PR TITLE
refactor: move the logic to determine accept type to 1 place

### DIFF
--- a/src/Common/Infrastructure/ApiController.cs
+++ b/src/Common/Infrastructure/ApiController.cs
@@ -36,9 +36,7 @@ namespace Common.Infrastructure
             Action<HttpStatusCode> handleNotOkResponseAction,
             CancellationToken cancellationToken)
         {
-            var acceptType = string.IsNullOrWhiteSpace(format)
-                ? requestHeaders.DetermineAcceptType()
-                : format.ToAcceptType();
+            var acceptType = requestHeaders.DetermineAcceptType(format);
 
             if (_redis != null)
             {
@@ -78,18 +76,12 @@ namespace Common.Infrastructure
             RequestHeaders requestHeaders,
             Action<HttpStatusCode> handleNotOkResponseAction,
             CancellationToken cancellationToken)
-        {
-            var acceptType = string.IsNullOrWhiteSpace(format)
-                ? requestHeaders.DetermineAcceptType()
-                : format.ToAcceptType();
-
-            return await GetFromBackendAsync(
+            => await GetFromBackendAsync(
                 restClient,
                 createBackendRequestFunc,
-                acceptType,
+                requestHeaders.DetermineAcceptType(format),
                 handleNotOkResponseAction,
                 cancellationToken);
-        }
 
         private static async Task<BackendResponse> GetFromBackendAsync(
             IRestClient restClient,

--- a/src/Public.Api/Infrastructure/RedisStoreKeyGenerator.cs
+++ b/src/Public.Api/Infrastructure/RedisStoreKeyGenerator.cs
@@ -86,7 +86,7 @@ namespace Public.Api.Infrastructure
             var requestHeaders = context.HttpRequest.GetTypedHeaders();
             var format = regexResult.Groups["format"];
             var acceptType = format.Success
-                ? format.Value.Substring(1).ToAcceptType()
+                ? requestHeaders.DetermineAcceptType(format.Value.Substring(1))
                 : requestHeaders.DetermineAcceptType();
 
             var cacheKey = string.Format(


### PR DESCRIPTION
- Move the logic to determine AcceptType based on format and headers to 1 place.
- Use existing Mime constant where possible