### PR TITLE
fix: GAWR-2866 'x-api-token' key is called 'Token' in the gateway mapping

### DIFF
--- a/src/Common/Infrastructure/Controllers/Attributes/ApiKeyAuthAttribute.cs
+++ b/src/Common/Infrastructure/Controllers/Attributes/ApiKeyAuthAttribute.cs
@@ -17,7 +17,7 @@ namespace Common.Infrastructure.Controllers.Attributes
     {
         private const string ApiKeyHeaderName = "x-api-key";
         private const string ApiKeyQueryName = "apikey";
-        private const string ApiTokenHeaderName = "x-api-token";
+        private const string ApiTokenHeaderName = "Token";
 
         private readonly string _requiredAccess;
 


### PR DESCRIPTION
The authorizer lambda function was also calling a keypath in the parameter store that didn't exist.
The fallback anon key was being triggered. 